### PR TITLE
ensure that the service returns states recognized by snpseq_packs

### DIFF
--- a/archive_verify/__init__.py
+++ b/archive_verify/__init__.py
@@ -1,0 +1,13 @@
+
+# mapping between the internal states of the service (keys) and the states that should be
+# returned in the response object (parsed by e.g. poll_status.py in snpseq_packs)
+REDIS_STATES = {
+    "queued": "pending",
+    "deferred": "pending",
+    "scheduled": "pending",
+    "started": "started",
+    "finished": "done",
+    "failed": "error",
+    "stopped": "cancelled",
+    "canceled": "cancelled"
+}

--- a/archive_verify/__init__.py
+++ b/archive_verify/__init__.py
@@ -1,13 +1,15 @@
 
+from arteria.web.state import State
+
 # mapping between the internal states of the service (keys) and the states that should be
 # returned in the response object (parsed by e.g. poll_status.py in snpseq_packs)
 REDIS_STATES = {
-    "queued": "pending",
-    "deferred": "pending",
-    "scheduled": "pending",
-    "started": "started",
-    "finished": "done",
-    "failed": "error",
-    "stopped": "cancelled",
-    "canceled": "cancelled"
+    "queued": State.PENDING,
+    "deferred": State.PENDING,
+    "scheduled": State.PENDING,
+    "started": State.STARTED,
+    "finished": State.DONE,
+    "failed": State.ERROR,
+    "stopped": State.CANCELLED,
+    "canceled": State.CANCELLED
 }

--- a/archive_verify/workers.py
+++ b/archive_verify/workers.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import datetime
 
+import archive_verify
 from archive_verify.pdc_client import PdcClient, MockPdcClient
 
 log = logging.getLogger(__name__)
@@ -89,7 +90,7 @@ def verify_archive(
     if not download_ok:
         log.debug("Download of {} failed.".format(archive_name))
         return {
-            "state": "error",
+            "state": archive_verify.REDIS_STATES["failed"],
             "msg": "failed to properly download archive from pdc",
             "path": dest
         }
@@ -104,14 +105,14 @@ def verify_archive(
             if not keep_downloaded_archive:
                 pdc_client.cleanup()
             return {
-                "state": "done",
+                "state": archive_verify.REDIS_STATES["finished"],
                 "path": output_file,
                 "msg": "Successfully verified archive md5sums."
             }
         else:
             log.info("Verify of {} failed.".format(archive))
             return {
-                "state": "error",
+                "state": archive_verify.REDIS_STATES["failed"],
                 "path": output_file,
                 "msg": "Failed to verify archive md5sums."
             }

--- a/archive_verify/workers.py
+++ b/archive_verify/workers.py
@@ -90,7 +90,7 @@ def verify_archive(
     if not download_ok:
         log.debug("Download of {} failed.".format(archive_name))
         return {
-            "state": archive_verify.REDIS_STATES["failed"],
+            "state": archive_verify.State.ERROR,
             "msg": "failed to properly download archive from pdc",
             "path": dest
         }
@@ -105,14 +105,14 @@ def verify_archive(
             if not keep_downloaded_archive:
                 pdc_client.cleanup()
             return {
-                "state": archive_verify.REDIS_STATES["finished"],
+                "state": archive_verify.State.DONE,
                 "path": output_file,
                 "msg": "Successfully verified archive md5sums."
             }
         else:
             log.info("Verify of {} failed.".format(archive))
             return {
-                "state": archive_verify.REDIS_STATES["failed"],
+                "state": archive_verify.State.ERROR,
                 "path": output_file,
                 "msg": "Failed to verify archive md5sums."
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp",
+    "arteria",
     "pyyaml",
     "redis",
     "rq"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -50,7 +50,7 @@ class HandlerTestCase(AioHTTPTestCase):
         request = await self.post_queued_request()
         assert request.status == 200
         resp = await request.json()
-        assert resp["status"] == "pending"
+        assert resp["status"] == "done"
         assert resp["action"] == "verify"
         assert resp["job_id"] != ""
 
@@ -58,7 +58,7 @@ class HandlerTestCase(AioHTTPTestCase):
         request = await self.post_queued_request(endpoint="download")
         assert request.status == 200
         resp = await request.json()
-        assert resp["status"] == "pending"
+        assert resp["status"] == "done"
         assert resp["action"] == "download"
         assert resp["job_id"] != ""
 


### PR DESCRIPTION
**What problems does this PR solve?**

The service was returning a http response object containing a value for "state" that snpseq_packs.poll_status did not recognize. This PR should fix that by introducing a mapping between the Redis vocabulary for states and the snpseq_packs vocabulary.

**How has the changes been tested?**

Only unit tests.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
